### PR TITLE
fix: import prisma from the db file, not the global variable

### DIFF
--- a/app/server/routers/_app.ts
+++ b/app/server/routers/_app.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import prisma from '../../db/prisma';
 import { router, publicProcedure } from '../trpc';
 import { dataRouter } from './data';
 import { eventsRouter } from './events';

--- a/app/server/routers/events.ts
+++ b/app/server/routers/events.ts
@@ -1,4 +1,5 @@
 import { publicProcedure, router } from '../trpc';
+import prisma from '../../db/prisma';
 
 export const eventsRouter = router({
 	fetch: publicProcedure.query(async () => {


### PR DESCRIPTION
Checklist:
- [x] I have read the contributing guidelines and code of conduct
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of ComputerStacks.
- [x] I have tested these changes thoroughly.

Quick fix for an issue where two trpc server files used the prisma global variable instead of the export from the file in `/app/db`
