### PR TITLE
fix: hide dropdown menu when closed

### DIFF
--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -72,9 +72,11 @@ function Navbar() {
 						width={40}
 					/>
 				</div>
-				<animated.div className="relative" style={springs}>
-					<Menu />
-				</animated.div>
+				<div style={{ display: menuOpen ? 'inline' : 'none' }}>
+					<animated.div className="relative" style={springs}>
+						<Menu />
+					</animated.div>
+				</div>
 			</div>
 			<div className="relative hidden h-min flex-row items-center justify-between gap-2 rounded-sm border-2 border-gray-4 bg-gray-3 p-3 outline-0 md:flex">
 				<Image


### PR DESCRIPTION
Checklist:
- [x] I have read the contributing guidelines and code of conduct
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of ComputerStacks.
- [x] I have tested these changes thoroughly

Quick fix for a bug where the links are invisible but not hidden when the dropdown menu is closed